### PR TITLE
Add Twitter profile links to Code of Conduct page

### DIFF
--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -1,5 +1,5 @@
 ---
-title: Code of Conduct 
+title: Code of Conduct
 layout: post
 ---
 
@@ -65,9 +65,9 @@ member of the volunteer team.
 <h2>Volunteer team</h2>
 
 <ul>
-<li>Stephen McCullough (@swmcc - stephen.mccullough@gmail.com)</li>
-<li>Stephen Holdsworth (@holsee)</li>
-<li>Maurice Kelly (@mauricerkelly)</li>
+<li>Stephen McCullough (<a href="https://twitter.com/swmcc">@swmcc</a> - stephen.mccullough@gmail.com)</li>
+<li>Stephen Holdsworth (<a href="https://twitter.com/holsee">@holsee</a>)</li>
+<li>Maurice Kelly (<a href="https://twitter.com/mauricerkelly">@mauricerkelly</a>)</li>
 </ul>
 
-<p>If you’d like to join the volunteer team please contact one of the above.</p> 
+<p>If you’d like to join the volunteer team please contact one of the above.</p>


### PR DESCRIPTION
The Code of Conduct page lists the Twitter handles for the volunteer
team, but does not expressly indicate that they are Twitter handles
or include links.

This PR adds links so that someone wanting to contact the volunteer
team can do so more easily.

(Also appears that I've trimmed some extraneous whitespace because
that's what good developers do.)